### PR TITLE
Add top-level BUILD file and put //:srcs into it

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,13 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = [
+      "BUILD",
+      "WORKSPACE",
+      "//os:srcs",
+      "//cpu:srcs",
+    ],
+)

--- a/BUILD
+++ b/BUILD
@@ -1,13 +1,11 @@
-package(
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "srcs",
     srcs = [
-      "BUILD",
-      "WORKSPACE",
-      "//os:srcs",
-      "//cpu:srcs",
+        "BUILD",
+        "WORKSPACE",
+        "//cpu:srcs",
+        "//os:srcs",
     ],
 )


### PR DESCRIPTION
This target will be used by Bazel to embed a release of 'platforms' into
the Bazel binary itself.

Progress towards https://github.com/bazelbuild/bazel/issues/8596