### PR TITLE
Add QNX as a possible constraint value

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -42,3 +42,8 @@ constraint_value(
     name = "windows",
     constraint_setting = ":os",
 )
+
+constraint_value(
+    name = "qnx",
+    constraint_setting = ":os",
+)


### PR DESCRIPTION
Have been using bazel to compile for QNX, would like to see it as a constraint value.