### PR TITLE
Add OS setting for devices with no OS

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -43,6 +43,7 @@ constraint_value(
     constraint_setting = ":os",
 )
 
+# For platforms with no OS, like microcontrollers.
 constraint_value(
     name = "none",
     constraint_setting = ":os",

--- a/os/BUILD
+++ b/os/BUILD
@@ -42,3 +42,8 @@ constraint_value(
     name = "windows",
     constraint_setting = ":os",
 )
+
+constraint_value(
+    name = "none",
+    constraint_setting = ":os",
+)


### PR DESCRIPTION
We have bazel targets which we cross compile for on bare metal chips.
"none" seems to capture this relatively well.

Looks like this got lost somehow when setting up copybara or something.