### PR TITLE
os: add openbsd to the constraint values

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -19,6 +19,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "openbsd",
+    constraint_setting = ":os",
+)
+
+constraint_value(
     name = "android",
     constraint_setting = ":os",
 )


### PR DESCRIPTION
There are notable differences from freebsd such that it warrants a constraint value.