### PR TITLE
os: add NixOS to the constraint values

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -76,3 +76,11 @@ constraint_value(
     name = "qnx",
     constraint_setting = ":os",
 )
+
+# NixOS uses the Linux kernel, but is not ABI-compatible with any
+# other Linux distribution. This is because the dynamic linker is in
+# a non-standard (and undefined) location on the filesystem.
+constraint_value(
+    name = "nixos",
+    constraint_setting = ":os",
+)


### PR DESCRIPTION
NixOS uses the Linux kernel, but that's where commonality with the
myriad Linux distributions out there stops. Like the different BSD's,
NixOS is sufficiently different that it warrants a constraint value.
In particular, no non-static binary has any chance of running on NixOS
unless it was specifically built for it, because the dynamic linker is
in a non-standard location. This means that toolchains downloaded as
part of host autoconfiguration that detect Linux (like
`go_register_toolchains()`) always fail on NixOS.

NixOS is a popular operating system used by thousands, one of the most
active projects on all of GitHub, and with more unique packages than
even Debian, Fedora or Gentoo according to https://repology.org/.

cc @aherrmann