### PR TITLE
Adds armv6-m support to the platforms library.

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -26,6 +26,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "armv6-m", # Commonly known as thumbv6
+    constraint_setting = ":cpu",
+)
+
+constraint_value(
     name = "arm64_32",
     constraint_setting = ":cpu",
 )


### PR DESCRIPTION
This is commonly known thumbv6. However, it appears that the name
is split between armv6-m and thumbv6 globally. I choose the arm
notation in order to be consistent with the other arm platforms.