### PR TITLE
Add an "incompatible" constraint value

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,3 +13,17 @@ filegroup(
         "//os:srcs",
     ],
 )
+
+# For use in Incompatible Target Skipping:
+# https://docs.bazel.build/versions/master/platforms.html#skipping-incompatible-targets
+#
+# Specifically this lets targets declare incompatibility with some set of
+# platforms. See
+# https://docs.bazel.build/versions/master/platforms.html#more-expressive-constraints
+# for some more details.
+constraint_setting(name = "incompatible_setting")
+
+constraint_value(
+    name = "incompatible",
+    constraint_setting = ":incompatible_setting",
+)


### PR DESCRIPTION
The bazel docs [1] currently recommend users to create an
`incompatible` constraint in their own code base. This constraint is
useful in expressing more advanced target compatibilities.

Currently every project has to create their own definition for this
constraint. That is unnecessary proliferation of something that can be
easily centralized here.

This patch makes it so users will be able to use the following pattern
in their BUILD files:

    cc_library(
        name = "unixish_lib",
        srcs = "unixish_lib.cc",
        target_compatible_with = select({
            "@platforms//os:osx": [],
            "@platforms//os:linux": [],
            "//conditions:default": ["@platforms//:incompatible"],
        ],
    )

[1]: https://docs.bazel.build/versions/master/platforms.html#skipping-incompatible-targets