### PR TITLE
Make aarch64 an alias of arm64

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -14,9 +14,9 @@ filegroup(
 constraint_setting(name = "cpu")
 
 # TODO(b/136237408): Remove this generic CPU name and replace with a specific one.
-constraint_value(
+alias(
     name = "aarch64",
-    constraint_setting = ":cpu",
+    actual = ":arm64",
 )
 
 # TODO(b/136237408): Remove this generic CPU name and replace with a specific one.


### PR DESCRIPTION
On Apple silicon Macs, auto-detected host platform constraints' cpu is
aarch64, but arm64 is used everywhere else. This change ensures that you
will get the same cpu when your target depends on an arm64 or an aarch64
cpu contraint.
