### PR TITLE
os: Adds RTOS constraint_values

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -91,3 +91,19 @@ constraint_value(
     name = "wasi",
     constraint_setting = ":os",
 )
+
+# Embedded realtime operating systems.
+constraint_value(
+    name = "embos",
+    constraint_setting = ":os",
+)
+
+constraint_value(
+    name = "freertos",
+    constraint_setting = ":os",
+)
+
+constraint_value(
+    name = "threadx",
+    constraint_setting = ":os",
+)


### PR DESCRIPTION
Adds Embos, FreeRTOS and ThreadX as constraint_values for
constraint_setting 'os'.

Example use case:
Select backends for pw_sync_* based on the OS for [Pigweed](https://github.com/google/pigweed).