### PR TITLE
Add a `riscv32` cpu constraint.

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -121,6 +121,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "riscv32",
+    constraint_setting = ":cpu",
+)
+
+constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )


### PR DESCRIPTION
We intend to use this contraint for cpu & compiler selection for the
OpenTitan project.  We are working on creating a riscv32 compiler
configuration in the bazel-embedded project.

Signed-off-by: Chris Frantz <cfrantz@google.com>