### PR TITLE
Add cpu value loongarch64

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -129,3 +129,8 @@ constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )
+
+constraint_value(
+	name = "loongarch64",
+	constraint_setting = ":cpu",
+)


### PR DESCRIPTION
we used `loongarch64` cpu contraint to build bazel in linux-loongarch64.
Signed-off-by: znley <shanjiantao@loongson.cn>