### PR TITLE
Add cpu value loong64 for LoongArch64

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -129,3 +129,9 @@ constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )
+
+# LoongArch64
+constraint_value(
+	name = "loong64",
+	constraint_setting = ":cpu",
+)


### PR DESCRIPTION
We intend to use `loong64` as cpu constraint for LoongArch64.

Signed-off-by: znley <merore256@outlook.com>