### PR TITLE
Improve the helper script to make a platforms release

### DIFF
--- a/distro/README.md
+++ b/distro/README.md
@@ -5,7 +5,8 @@ WARNING: These are what worked last time. Reality might be different.
 ## Step 1: Make the release
 
 - Pick a new version number
-- Run distro/makerel.sh *version*
+- Update version.bzl
+- Run distro/makerel.sh
 - Go to the [Releases](https://github.com/bazelbuild/platforms/releases) page
 - Draft a new release
   - Name the release with a version number

--- a/distro/makerel.sh
+++ b/distro/makerel.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-if [[ $# != 1 ]] ; then
-  echo "usage: $0 version"
-  exit 1
-fi
-version="$1"
-
 if [[ ! -f WORKSPACE ]] ; then
   echo 'You must run this command from the top of the workspace.'
   exit 1
 fi
+
+if [[ ! -f version.bzl ]] ; then
+  version.bzl is missing.
+  exit 1
+fi
+version=$(sed -n -e 's/^version *= *"\(.*\)".*$/\1/p'  version.bzl)
 
 # tar on macos builds a file with different checksums each time.
 if [[ $(uname) != 'Linux' ]] ; then
@@ -19,9 +19,10 @@ fi
 
 
 dist_file="/tmp/platforms-${version}.tar.gz"
-tar czf "$dist_file" BUILD LICENSE WORKSPACE cpu os
+tar czf "$dist_file" BUILD LICENSE WORKSPACE version.bzl cpu os
 sha256=$(shasum -a256 "$dist_file" | cut -d' ' -f1)
 
+path="github.com/bazelbuild/platforms/releases/download/$version/platforms-$version.tar.gz"
 cat <<INP
 
 
@@ -30,7 +31,7 @@ cat <<INP
 3. Upload $dist_file as an artifact.
 4. Copy $dist_file to the mirror site.
 5. Create the release.
-6. Update Bazel to point to this new release. See the readme.
+6. Update Bazel distdir_deps.bzl to point to this new release. See the readme.
 
 =============== CUT HERE =============== 
 **WORKSPACE setup**
@@ -40,12 +41,27 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "platforms",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/$version/platforms-$version.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/$version/platforms-$version.tar.gz",
+        "https://mirror.bazel.build/${path}",
+        "https://${path}",
     ],
     sha256 = "$sha256",
 )
 \`\`\`
 =============== CUT HERE =============== 
-INP
 
+Use this to update Bazel's distdir_deps.bzl
+
+
+        "archive": "platforms-$version.tar.gz",
+        "sha256": "$sha256",
+        "urls": [
+            "https://mirror.bazel.build/${path}",
+            "https://${path}",
+        ],
+
+Copy/paste this to mirror the file.
+
+  gsutil cp /tmp/platforms-$version.tar.gz "gs://bazel-mirror/${path}"
+  gsutil setmeta -h "Cache-Control: public, max-age=31536000" "gs://bazel-mirror/${path}"
+
+INP

--- a/version.bzl
+++ b/version.bzl
@@ -1,0 +1,16 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The version of bazelbuild/platforms."""
+
+version = "0.0.6"


### PR DESCRIPTION
- use version.bzl to get the version
- add instructions to mirror the tarball
- remind people to update bazel by fixing distdir_deps.bzl