### PR TITLE
Add loongarch64 support

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -129,3 +129,8 @@ constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )
+
+constraint_value(
+    name = "loongarch64",
+    constraint_setting = ":cpu",
+)


### PR DESCRIPTION
Compile bazel on LoongArch with errors, so add this commit. I already successfully built bazel and run bazelbuild/examples.
```
[loongson@localhost output]$ arch
loongarch64
[loongson@localhost output]$ pwd
/home/loongson/zhangna/bazel-LA/output
[loongson@localhost output]$ ls
bazel
[loongson@localhost output]$ file bazel 
bazel: ELF 64-bit LSB executable, *unknown arch 0x102* version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld.so.1, for GNU/Linux 4.15.0, BuildID[sha1]=6b74aec09bbf4d946d37c1b9b0e46302770deae1, not stripped
```