### PR TITLE
Add bzlmod module

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,3 +12,10 @@ tasks:
   windows:
     build_targets:
     - "//..."
+  ubuntu2004_bzlmod:
+    name: "With bzlmod"
+    platform: ubuntu2004
+    build_targets:
+    - "//..."
+    build_flags:
+    - "--experimental_enable_bzlmod"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "platforms",
+    version = "0.0.6",
+)


### PR DESCRIPTION
Unfortunately loading the version from `version.bzl` doesn't work it seems.

See https://github.com/bazelbuild/bazel-central-registry/issues/124