### PR TITLE
Add common i386 alias

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -19,6 +19,11 @@ alias(
     actual = ":arm64",
 )
 
+alias(
+    name = "ia32",
+    actual = ":i386",
+)
+
 # TODO(b/136237408): Remove this generic CPU name and replace with a specific one.
 constraint_value(
     name = "arm",


### PR DESCRIPTION
Wanted to ask if you would be open to something like this? I saw some precedent in the file but wasn't sure if this was a pattern you wanted to avoid potentially.

I ran into this writing a new rule set and was running into writing a bunch of additional logic that could have just been avoided with an alias like this so I figured I would submit it as a pull request and see what y'all think :)  