### PR TITLE
Add cortex-r52 r82 cpus

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -13,6 +13,24 @@ filegroup(
 # To add a new constraint_value see https://github.com/bazelbuild/platforms.
 constraint_setting(name = "cpu")
 
+# New cpu values should refer to specific, highly available CPU implementations,
+# not broad architectures.  It should be possible to select the right compiler
+# options by just by knowing the cpu. This can be a difficult evaluation for
+# ARM variations, where there are many possibilities for customization within
+# an architecture.
+#
+# 1. No private names are be allowed. If you build your own custom ARM chips,
+#    then define them locally within your organization.
+# 2. All CPU values must be clear that they are for a 32 or a 64 bit
+#    implementation. For example, cortex-r52 is a 32 bit processor, and
+#    cortex-r82 is a 64 bit processor, but both are armv8-r architecture.
+#    We use the specific processor names because armv8-r is insufficient to
+#    select proper compiler options.
+#
+# Many of the name here are legacy values and probably violate these conditions.
+# We'll try to clean those up over time.
+
+
 # TODO(b/136237408): Remove this generic CPU name and replace with a specific one.
 alias(
     name = "aarch64",

--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -73,13 +73,6 @@ constraint_value(
     constraint_setting = ":cpu",
 )
 
-# Cortex-R52
-constraint_value(
-    name = "armv8-r",
-    constraint_setting = ":cpu",
-    deprecation = "Do not use. Use a specific cpu product",
-)
-
 constraint_value(
     name = "arm64_32",
     constraint_setting = ":cpu",

--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -59,6 +59,7 @@ constraint_value(
 constraint_value(
     name = "armv8-r",
     constraint_setting = ":cpu",
+    deprecation = "Do not use. Use a specific cpu product",
 )
 
 constraint_value(
@@ -83,6 +84,16 @@ constraint_value(
 
 constraint_value(
     name = "armv7k",
+    constraint_setting = ":cpu",
+)
+
+constraint_value(
+    name = "cortex-r52",
+    constraint_setting = ":cpu",
+)
+
+constraint_value(
+    name = "cortex-r82",
     constraint_setting = ":cpu",
 )
 


### PR DESCRIPTION
After much discussion about this, I think we should add these specific CPU constraint values to replace the imprecise "armv8-r".

- the names are of specific CPUs shipping from ARM
- armv8-r is really the name of an architecture specification. It can be 
  implemented in 32 bit (r52) or 64 bit (r82). So selected on it is not really useful

