### PR TITLE
Add rules_license style declaration.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,7 +8,7 @@ package(
 license(
     name = "license",
     license_kinds = [
-        "@rules_license//licenses/spdx:Apache-2.0"
+        "@rules_license//licenses/spdx:Apache-2.0",
     ],
     license_text = "LICENSE",
 )

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,17 @@
-package(default_visibility = ["//visibility:public"])
+load("@rules_license//rules:license.bzl", "license")
 
-licenses(["notice"])
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+license(
+    name = "license",
+    license_kinds = [
+        "@rules_license//licenses/spdx:Apache-2.0"
+    ],
+    license_text = "LICENSE",
+)
 
 exports_files(["LICENSE"])
 

--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,10 @@ license(
     license_text = "LICENSE",
 )
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    "MODULE.bazel",
+])
 
 filegroup(
     name = "srcs",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "platforms",
-    version = "0.0.8",  # keep in sync with version.bzl
+    version = "0.0.7",  # keep in sync with version.bzl
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_license", version = "0.0.3")
+bazel_dep(name = "rules_license", version = "0.0.4")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,7 @@
 module(
     name = "platforms",
-    version = "0.0.6",  # keep in sync with version.bzl
+    version = "0.0.8",  # keep in sync with version.bzl
     compatibility_level = 1,
 )
+
+bazel_dep(name = "rules_license", version = "0.0.3")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_license",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
+        "https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
     ],
-    sha256 = "00ccc0df21312c127ac4b12880ab0f9a26c1cff99442dc6c5a331750360de3c3",
+    sha256 = "6157e1e68378532d0241ecd15d3c45f6e5cfd98fc10846045509fb2a7cc9e381",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,5 +7,5 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
     ],
-    # sha256 = "4865059254da674e3d18ab242e21c17f7e3e8c6b1f1421fffa4c5070f82e98b5",
+    sha256 = "00ccc0df21312c127ac4b12880ab0f9a26c1cff99442dc6c5a331750360de3c3",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,9 @@
 workspace(name = "platforms")
+
+http_archive(
+    name = "rules_license",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
+    ],
+    # sha256 = "4865059254da674e3d18ab242e21c17f7e3e8c6b1f1421fffa4c5070f82e98b5",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "platforms")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "rules_license",
     urls = [

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,4 @@
+# Include dependencies which are only needed for development here.
+#
+# Even if this is empty, you need it with bzlmod enable to prevent
+# bzlmod from bringing in WORKSPACE too.

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,18 @@
+load("//:version.bzl", "version")
+
+package(default_visibility = ["//visibility:private"])
+
+# This is a quick hack to make sure that version.bzl agrees with MODULE.bazel
+# It only works from Linux, but that is sufficient, becuase we do a presubmit
+# run linux, so we will still catch a mismatch.
+genrule(
+    name = "versions_match",
+    cmd = """grep 'version = "%s",' $(location //:MODULE.bazel) >$(location :found_it)""" % version,
+    outs = ["found_it"],
+    tools = [
+        "//:MODULE.bazel",
+    ] ,
+    target_compatible_with = [
+        "//os:linux",
+    ],
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -7,15 +7,15 @@ package(default_visibility = ["//visibility:private"])
 # run linux, so we will still catch a mismatch.
 genrule(
     name = "versions_match",
+    outs = ["found_it"],
     cmd = ";\n".join([
         """echo version: %s""" % version,
         """grep 'version = "%s",' $(location //:MODULE.bazel) >$(location :found_it)""" % version,
     ]),
-    outs = ["found_it"],
-    tools = [
-        "//:MODULE.bazel",
-    ] ,
     target_compatible_with = [
         "//os:linux",
+    ],
+    tools = [
+        "//:MODULE.bazel",
     ],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -7,7 +7,10 @@ package(default_visibility = ["//visibility:private"])
 # run linux, so we will still catch a mismatch.
 genrule(
     name = "versions_match",
-    cmd = """grep 'version = "%s",' $(location //:MODULE.bazel) >$(location :found_it)""" % version,
+    cmd = ";\n".join([
+        """echo version: %s""" % version,
+        """grep 'version = "%s",' $(location //:MODULE.bazel) >$(location :found_it)""" % version,
+    ]),
     outs = ["found_it"],
     tools = [
         "//:MODULE.bazel",

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of bazelbuild/platforms."""
 
-version = "0.0.6"
+version = "0.0.7"


### PR DESCRIPTION
- Done for both WORKSPACE and bzlmod styles
- The dependency is different because rules_license is not up to date in the BCR. I'll correct that at the next rules_license release.
- There should be a release after this, but it should wait until we can update to the next rules_license release

In spite of the last point, doing this now allows testing as early as possible.