### PR TITLE
cpu: add ebpf

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -109,6 +109,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "ebpf",
+    constraint_setting = ":cpu",
+)
+
+constraint_value(
     name = "i386",
     constraint_setting = ":cpu",
 )


### PR DESCRIPTION
Adds eBPF CPU architecture to platforms.

**Rationale**

eBPF is an instruction set that has found widespread use across the industry with working software and hardware implementations, as well as compilers and commercial variants.

I believe eBPF therefore qualifies as a ubiquitous and non-area-specific CPU constraint value.

eBPF is a virtual CPU architecture used in the [Linux kernel](https://github.com/torvalds/linux/tree/master/kernel/bpf), [soon FreeBSD](https://people.freebsd.org/~hrs/hrs-20190919-ebpf.pdf), [Windows](https://github.com/microsoft/xdp-for-windows). Hardware implementations on FPGA [exist](https://www.usenix.org/conference/osdi20/presentation/brunella).

A working LLVM target for eBPF exists [here](https://github.com/llvm/llvm-project/tree/main/llvm/lib/Target/BPF), with C and [Rust](https://aya-rs.dev/) frontends. A general-purpose programmable ISA variant (sBPF) exists [here](https://github.com/solana-labs/llvm-project/tree/solana-rustc/15.0-2022-08-09/llvm/lib/Target/BPF).

I'm currently working on an open-source LLVM toolchain for rules_cc and would like to use target selection as such:

```
llvm_toolchain(
    name = "ebpf_clang",
    llvm_repo = "llvm15",
    target_arch = "bpf",
    target_compatible_with = [
        "@platforms//os:none",
        "@platforms//cpu:ebpf",
    ],
)
``` 

(which will result in `clang -target bpf-unknown-unknown` -- part of mainline Clang/LLVM since at least LLVM 8.0)

**Resources**

Website: https://ebpf.io/
ISA spec: https://docs.kernel.org/bpf/instruction-set.html