### PR TITLE
Add ppc64le cpu

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -145,6 +145,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "ppc64le",
+    constraint_setting = ":cpu",
+)
+
+constraint_value(
     name = "s390x",
     constraint_setting = ":cpu",
 )


### PR DESCRIPTION
This is a specific cpu variant of ppc64 in little-endian mode.

GOARCH has equivalent: https://github.com/golang/go/blob/master/src/go/build/syslist.go#L73

Debian also builds (though with weird naming): https://wiki.debian.org/ppc64el

It is weird that the other entries here are ppc and ppc32, I would actually expect ppc and ppc64 but :shrug: