### PR TITLE
Add :aarch32 :aarch64 and make :arm64 alias for :aarch64

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -30,17 +30,19 @@ constraint_setting(name = "cpu")
 # Many of the name here are legacy values and probably violate these conditions.
 # We'll try to clean those up over time.
 
-
-# TODO(b/136237408): Remove this generic CPU name and replace with a specific one.
-alias(
-    name = "aarch64",
-    actual = ":arm64",
+constraint_value(
+    name = "aarch32",
+    constraint_setting = ":cpu",
 )
 
-# TODO(b/136237408): Remove this generic CPU name and replace with a specific one.
 constraint_value(
-    name = "arm",
+    name = "aarch64",
     constraint_setting = ":cpu",
+)
+
+alias(
+    name = "arm",
+    actual = ":aarch32",
 )
 
 # Cortex-M0, Cortex-M0+, Cortex-M1
@@ -73,13 +75,13 @@ constraint_value(
     constraint_setting = ":cpu",
 )
 
-constraint_value(
-    name = "arm64_32",
-    constraint_setting = ":cpu",
+alias(
+    name = "arm64",
+    actual = ":aarch64",
 )
 
 constraint_value(
-    name = "arm64",
+    name = "arm64_32",
     constraint_setting = ":cpu",
 )
 


### PR DESCRIPTION
"aarch64" is the perferred name and used prevailingly on Linux. See https://nickdesaulniers.github.io/blog/2023/03/10/disambiguating-arm/

Apple and Windows platforms unfortunately use "arm64". They can still use the alias.

While here, add :aarch32 as well.

Close #68