### PR TITLE
Add support for ARMv8-m Extensions

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -69,10 +69,9 @@ constraint_value(
     constraint_setting = ":cpu",
 )
 
-# Cortex-M23, Cortex-M33, Cortex-M35P
-constraint_value(
+alias(
     name = "armv8-m",
-    constraint_setting = ":cpu",
+    actual = "//cpu/armv8-m",
 )
 
 alias(

--- a/cpu/armv8-m/BUILD
+++ b/cpu/armv8-m/BUILD
@@ -1,0 +1,10 @@
+package(
+    default_visibility = ["//visibility:public"],
+    default_applicable_licenses = ["//:license"],
+)
+
+# Cortex-M23, Cortex-M33, Cortex-M35P
+constraint_value(
+    name = "armv8-m",
+    constraint_setting = "//cpu",
+)

--- a/cpu/armv8-m/extensions/BUILD
+++ b/cpu/armv8-m/extensions/BUILD
@@ -1,0 +1,35 @@
+# ARMv8-m Extension Definitions
+
+load("//:utils.bzl", "boolean_extension_constraint")
+
+package(
+    default_visibility = ["//visibility:public"],
+    default_applicable_licenses = ["//:license"],
+)
+
+# Armv8-m Extenstions defined in:
+# https://developer.arm.com/documentation/107656/0100/Introduction-to-Armv8-M-architecture/Baseline-and-Mainline
+
+# Main extension.
+boolean_extension_constraint("m")
+
+# Floating point extension.
+boolean_extension_constraint("fp")
+
+# M-Profile Vector Extension.
+boolean_extension_constraint("mve")
+
+# Memory Protection Unit.
+boolean_extension_constraint("mpu")
+
+# Digital Signal Processing.
+boolean_extension_constraint("dsp")
+
+# Debug.
+boolean_extension_constraint("db")
+
+# Security aka Trustzone.
+boolean_extension_constraint("s")
+
+# Reliability, Availability, and Serviceability.
+boolean_extension_constraint("ras")

--- a/utils.bzl
+++ b/utils.bzl
@@ -1,0 +1,28 @@
+"""Utility macros."""
+
+def boolean_extension_constraint(name):
+    """
+    Macro for defining constraints for an extension that is optionally present.
+
+    Defines a `constraint_setting`, <name>_setting and two `constraint_values`,
+    no_<name> and <name>.
+    The setting defaults to `no_<name>` for maximum compatibility, since
+    generally code compiled without extension support can run on a machine with
+    the extension present.
+    """
+
+    setting_name = "%s_setting" % name
+    native.constraint_setting(
+        name = setting_name,
+        default_constraint_value = "no_%s" % name,
+    )
+
+    native.constraint_value(
+        name = "no_%s" % name,
+        constraint_setting = setting_name,
+    )
+
+    native.constraint_value(
+        name = name,
+        constraint_setting = setting_name,
+    )


### PR DESCRIPTION
ARMv8-m supports 8 different optional extensions. Instead of supporting a curated set permutations, create new constraint setting for each extension.

This is modeled after #63 