### PR TITLE
Added VXWorks OS

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -48,6 +48,12 @@ constraint_value(
     constraint_setting = ":os",
 )
 
+# For the VXworks OS, usefull for embedded systems
+constraint_value(
+    name = "vxworks",
+    constraint_setting = ":os",
+)
+
 # For platforms with no OS, like microcontrollers.
 constraint_value(
     name = "none",


### PR DESCRIPTION
VXworks in among the most popular OS for the embedded world, having it in Bazel would be nice