### PR TITLE
Add Apple visionos.

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -83,6 +83,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "visionos",
+    constraint_setting = ":os",
+)
+
+constraint_value(
     name = "qnx",
     constraint_setting = ":os",
 )


### PR DESCRIPTION
I'm not really satisified with this PR. The number of Apple specific platforms has grown to the point where we may want to refactor them. The question I would focus on is how various toolchain matches and select clauses go.

Do we see things like:

```
foo = select({
  ".../os:linux": A,
  ".../os:windows": B,
  ".../os:macos": C,
  ".../os:watchos": C,
  ".../os:visionos": C,
})
```

Where C is the same for all the apple platforms?

Or, do we see real distinctions across the various per-device OSes. Or a mix of both? And, do we see the fanout of the Apple OSes done with a select_or wrapper, so users end up seeing the simple selection of just apple, linux, or windows, but we buried complexity elsewhere?