### PR TITLE
Add UEFI OS

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -122,3 +122,8 @@ constraint_value(
     name = "chromiumos",
     constraint_setting = ":os",
 )
+
+constraint_value(
+    name = "uefi",
+    constraint_setting = ":os",
+)


### PR DESCRIPTION
This adds UEFI as an OS. It specifies pretty much everything in order to qualify for an OS (ABI, entrypoint, standard interfaces) and there are compiler targets for it (for example Rust's x86_64-unknown-uefi), so I think it makes sense to have it as an OS in platforms.