### PR TITLE
Define constraint for emscripten os

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -106,6 +106,11 @@ constraint_value(
     constraint_setting = ":os",
 )
 
+constraint_value(
+    name = "emscripten",
+    constraint_setting = ":os",
+)
+
 # WASI (WebAssembly System Interface)
 # https://github.com/bytecodealliance/wasmtime/blob/main/docs/WASI-overview.md
 constraint_value(


### PR DESCRIPTION
This is to be used for WebAssembly built with the emscripten toolchain, with cpus wasm32/wasm64.