### PR TITLE
Add filegroup targets for .bzl files in the `host` package

### DIFF
--- a/host/BUILD.bazel
+++ b/host/BUILD.bazel
@@ -16,3 +16,19 @@ platform(
     constraint_values = HOST_CONSTRAINTS,
 )
 
+# The following filegroup targets are essentially bzl_library targets.
+# We don't directly use bzl_library to avoid a dependency on bazel-skylib.
+filegroup(
+    name = "constraints_lib",
+    srcs = [
+        "constraints.bzl",
+        "@host_platform//:constraints.bzl",
+    ],
+)
+
+filegroup(
+    name = "extension_lib",
+    srcs = [
+        "extension.bzl",
+    ],
+)


### PR DESCRIPTION
This allows users of e.g. `//host:constraints.bzl` to use Stardoc.

Fixes https://github.com/bazelbuild/platforms/pull/89