### PR TITLE
Fix and add `platform_data` to release archive

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,6 +26,7 @@ filegroup(
         "//cpu:srcs",
         "//os:srcs",
         "//host:srcs",
+        "//experimental/platform_data:srcs",
     ],
 )
 

--- a/distro/makerel.sh
+++ b/distro/makerel.sh
@@ -19,7 +19,7 @@ fi
 
 
 dist_file="/tmp/platforms-${version}.tar.gz"
-tar czf "$dist_file" BUILD LICENSE MODULE.bazel WORKSPACE WORKSPACE.bzlmod version.bzl cpu os host
+tar czf "$dist_file" BUILD LICENSE MODULE.bazel WORKSPACE WORKSPACE.bzlmod version.bzl cpu os host experimental
 sha256=$(shasum -a256 "$dist_file" | cut -d' ' -f1)
 
 path="github.com/bazelbuild/platforms/releases/download/$version/platforms-$version.tar.gz"

--- a/experimental/platform_data/BUILD
+++ b/experimental/platform_data/BUILD
@@ -1,0 +1,9 @@
+exports_files([
+    "defs.bzl",
+])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)

--- a/experimental/platform_data/BUILD.bazel
+++ b/experimental/platform_data/BUILD.bazel
@@ -1,3 +1,0 @@
-exports_files([
-    "defs.bzl",
-])

--- a/experimental/platform_data/defs.bzl
+++ b/experimental/platform_data/defs.bzl
@@ -20,11 +20,11 @@ py_binary(
 )
 
 Regardless of what platform the top-level :flasher binary is built for,
-the :foo_embedded target will be built for //my/new:platform. 
+the :foo_embedded target will be built for //my/new:platform.
 
 Note that if you depend on :foo_embedded it's not exactly the same as depending on :foo, since it won't forward all the same providers. In the future, we can extend this to add some common providers as needed."""
 
-def _target_platform_transition_impl(attr):
+def _target_platform_transition_impl(_settings, attr):
     return {
         "//command_line_option:platforms": str(attr.platform),
     }
@@ -40,7 +40,7 @@ _target_platform_transition = transition(
 def _platform_data_impl(ctx):
     target = ctx.attr.target
 
-    default_info = target[DefaultInfo]
+    default_info = target[0][DefaultInfo]
     files = default_info.files
     original_executable = default_info.files_to_run.executable
     runfiles = default_info.default_runfiles


### PR DESCRIPTION
The rule was missing from the archive and also had a bug that would cause it to fail if used.