### PR TITLE
Add `uefi` os constraint

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -127,3 +127,8 @@ constraint_value(
     name = "chromiumos",
     constraint_setting = ":os",
 )
+
+constraint_value(
+    name = "uefi",
+    constraint_setting = ":os",
+)


### PR DESCRIPTION
A duplicate of #76, since that PR seems to be abandoned after almost a year of no updates from the original author.

This PR creates a `uefi` OS constraint. UEFI is a firmware environment with clear parallels to a conventional OS:

||Linux|Windows|UEFI|
|-|-|-|-|
|Binary Format|EFI|PE/COFF|PE/COFF|
|Entrypoint|`main`|`main`|`efi_main`|
|The address of a "symbol"|`dlsym`|`GetProcAddress`|`SystemTable->BootServices->LocateProtocol`|

There are compilers that treat UEFI as an OS:
- Rust's `*-unknown-uefi` targets.
- LLVM treats UEFI as a Windows subsystem (`subsystem:efi_application`.)

This is also blocking at least one project downstream. (bazelbuild/rules_rust#2142)

This closes #98