### PR TITLE
Add `bpfbe` and `bpfle` cpu constraints

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -188,3 +188,15 @@ constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )
+
+# BPF (big endian)
+constraint_value(
+    name = "bpfbe",
+    constraint_setting = ":cpu",
+)
+
+# BPF (little endian)
+constraint_value(
+    name = "bpfle",
+    constraint_setting = ":cpu",
+)


### PR DESCRIPTION
This patch creates two cpu constraints, enabling downstream toolchains the ability to generate eBPF bytecode.

Please note, that compiler target triples are named using `bpf*` instead of `ebpf*`.

|Compiler|Target Triple|Notes|
|-|-|-|
|clang|`bpf`<br/>`bpfbe`<br/>`bpfle`|Default endianess matches compiler host/"execute" target.|
|gcc|`bpf-unknown-none`|`-mlittle-endian`/`-mbig-endian` compiler flags. Little endian is the default.|
|rustc|`bpfbe-unknown-none`<br/>`bpfle-unknown-none`|
