### PR TITLE
Properly translate ppc64le

### DIFF
--- a/host/extension.bzl
+++ b/host/extension.bzl
@@ -3,8 +3,10 @@ def _translate_cpu(arch):
         return "x86_32"
     if arch in ["amd64", "x86_64", "x64"]:
         return "x86_64"
-    if arch in ["ppc", "ppc64", "ppc64le"]:
+    if arch in ["ppc", "ppc64"]:
         return "ppc"
+    if arch in ["ppc64le"]:
+        return "ppc64le"
     if arch in ["arm", "armv7l"]:
         return "arm"
     if arch in ["aarch64"]:


### PR DESCRIPTION
Properly translate ppc64le architecture to the '@platforms//cpu:ppc64le' constraint value when detected on the host.