### PR TITLE
Add alias for `amd64` to `x86_64`

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -60,6 +60,11 @@ constraint_value(
 )
 
 alias(
+    name = "amd64",
+    actual = ":x86_64",
+)
+
+alias(
     name = "arm",
     actual = ":aarch32",
 )


### PR DESCRIPTION
`amd64` gets returned by `repository_ctx.os.arch`, and yet the CPU constraint only has `x86_64`. This becomes un-ergonomic when trying to set up repository and toolchain rules—I constantly have to ask myself which is which/try it out. `arm64` has an alias to `aarch64`, so there is precedent for including an equivalent name when the implementation-canonical name may not be as friendly or widely known.