### PR TITLE
Prepare for v1.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "platforms",
-    version = "0.0.11",  # keep in sync with version.bzl
+    version = "1.0.0",  # keep in sync with version.bzl
     compatibility_level = 1,
 )
 

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of bazelbuild/platforms."""
 
-version = "0.0.11"
+version = "1.0.0"


### PR DESCRIPTION
Backwards incompatible changes to this module are already effectively impossible since it's a direct dependency of almost every other Bazel module. As a foundational module, it should reflect this stability in its version number.