### PR TITLE
Add package_metadata target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,11 +1,34 @@
-load("@rules_license//rules:license.bzl", "license")
+load("@package_metadata//licenses/rules:license.bzl", "license")
+load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
+load("@rules_license//rules:license.bzl", deprecated_license = "license")
 
 package(
-    default_applicable_licenses = [":license"],
+    default_applicable_licenses = [
+        ":license",
+        ":package_metadata",
+    ],
     default_visibility = ["//visibility:public"],
 )
 
+package_metadata(
+    name = "package_metadata",
+    attributes = [
+        ":package_metadata_license",
+    ],
+    purl = "pkg:bazel/{}@{}".format(
+        module_name(),
+        module_version(),
+    ) if module_version() else "pkg:bazel/{}".format(module_name()),
+    visibility = ["//visibility:public"],
+)
+
 license(
+    name = "package_metadata_license",
+    kind = "@package_metadata//licenses/spdx:Apache-2.0",
+    text = "LICENSE",
+)
+
+deprecated_license(
     name = "license",
     license_kinds = [
         "@rules_license//licenses/spdx:Apache-2.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "package_metadata", version = "0.0.3")
 bazel_dep(name = "rules_license", version = "0.0.7")
 
 host_platform = use_extension("//host:extension.bzl", "host_platform")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,10 +3,20 @@ workspace(name = "platforms")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "package_metadata",
+    sha256 = "0e89367f1cb6d93a5a1afea4b55b11ea6b28f63f653b47154153677ca7d4afea",
+    strip_prefix = "supply-chain-0.0.3/metadata",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazel-contrib/supply-chain/releases/download/v0.0.3/supply-chain-v0.0.3.tar.gz",
+        "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.3/supply-chain-v0.0.3.tar.gz",
+    ],
+)
+
+http_archive(
     name = "rules_license",
+    sha256 = "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
         "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
     ],
-    sha256 = "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
 )


### PR DESCRIPTION
`@package_metadata` is the successor to `@rules_license`.