### PR TITLE
Add `wasip1` and `wasip2` os constraints

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -111,10 +111,22 @@ constraint_value(
     constraint_setting = ":os",
 )
 
-# WASI (WebAssembly System Interface)
-# https://github.com/bytecodealliance/wasmtime/blob/main/docs/WASI-overview.md
+# WASI Preview 1 (WebAssembly System Interface)
+# https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
 constraint_value(
+    name = "wasip1",
+    constraint_setting = ":os",
+)
+
+alias(
     name = "wasi",
+    actual = ":wasip1",
+)
+
+# WASI Preview 2 is ABI-incompatible with Preview 1.
+# https://github.com/WebAssembly/WASI/blob/main/preview2/README.md
+constraint_value(
+    name = "wasip2",
     constraint_setting = ":os",
 )
 


### PR DESCRIPTION
## Summary

Adds separate constraint values for WASI Preview 1 and Preview 2:
- `@platforms//os:wasip1` for WASI Preview 1 (stable)  
- `@platforms//os:wasip2` for WASI Preview 2 (ABI-incompatible with Preview 1)
- Maintains backward compatibility with `@platforms//os:wasi` alias → `wasip1`

## Use Case

Enables rule sets like `rules_rust` to distinguish between WASI versions without custom constraints.

## References

- Closes #121
- Enables bazelbuild/rules_rust#3507 to use standard @platforms constraints