### PR TITLE
Add support for sw_64 CPU architecture

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -188,3 +188,8 @@ constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )
+
+constraint_value(
+    name = "sw_64",
+    constraint_setting = ":cpu",
+)

--- a/host/extension.bzl
+++ b/host/extension.bzl
@@ -17,6 +17,8 @@ def _translate_cpu(arch):
         return "mips64"
     if arch in ["riscv64"]:
         return "riscv64"
+    if arch in ["sw_64"]:
+        return "sw_64"
     return None
 
 def _translate_os(os):


### PR DESCRIPTION

In this commit, support for a new architecture sw_64 is added to bazel. sw_64 is a new RISC ISA, which is a bit like RISC-V. Though it is a rather new ISA, it has been added to openEuler and openAnolis port since 2020. So supporting this new architecture is meaningful.
It's PR is to solve compilation failure on sw_64 architecture.

Binutils has identified EM_SW64 is 268, I hope bazel can accept this patch. Thanks.

https://en.wikipedia.org/wiki/Sunway_(processor)

More information about sw_64 ISA:
```bash
$ uname -m
sw_64
$ gcc -E -dM - < /dev/null|grep __sw_64__
#define __sw_64__ 1
$ gcc -E -dM - < /dev/null|grep BYTE_ORDER
#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
```
