### PR TITLE
Add aix os constraint.

### DIFF
--- a/os/BUILD
+++ b/os/BUILD
@@ -132,3 +132,8 @@ constraint_value(
     name = "uefi",
     constraint_setting = ":os",
 )
+
+constraint_value(
+    name = "aix",
+    constraint_setting = ":os",
+)


### PR DESCRIPTION
Believe it or not, I may have to build for AIX with Bazel in the foreseable future. Having this here makes it possible to upstream that case into select() clauses of legacy C code that has made its way into the BCR.