### PR TITLE
Add bpfel/bpfeb CPU constraint values

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -188,3 +188,13 @@ constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )
+
+constraint_value(
+    name = "bpfel",
+    constraint_setting = ":cpu",
+)
+
+constraint_value(
+    name = "bpfeb",
+    constraint_setting = ":cpu",
+)


### PR DESCRIPTION
These names are used in clang (see
https://github.com/llvm/llvm-project/blob/6bee6b2/llvm/include/llvm/TargetParser/Triple.h#L1154-L1157)
and Rust (see
https://github.com/rust-lang/rust/blob/f5e2df7/src/doc/rustc/src/platform-support.md?plain=1#L311-L312).

This addition is a prerequisite for teaching `rules_rust` about these
constraints.

This is an alternative to https://github.com/bazelbuild/platforms/pull/99 which
spelled these names incorrectly.

Closes https://github.com/bazelbuild/platforms/pull/99.
