### PR TITLE
Add a CPU constraint for loongarch64.

### DIFF
--- a/cpu/BUILD
+++ b/cpu/BUILD
@@ -188,3 +188,8 @@ constraint_value(
     name = "riscv64",
     constraint_setting = ":cpu",
 )
+
+constraint_value(
+    name = "loongarch64",
+    constraint_setting = ":cpu",
+)


### PR DESCRIPTION
Based on https://en.wikipedia.org/wiki/Loongson, the architecture name seems to be "loongarch", so using "loongarch64" to distinguish the 64-bit variant seems useful. Given that this is new, I do not see a value in adding an alias for `loong64` since that seems likely to confuse users about which name is correct.

Fixes #107.