### PR TITLE
Fix tests for Bazel 9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,5 +7,7 @@ module(
 bazel_dep(name = "package_metadata", version = "0.0.3")
 bazel_dep(name = "rules_license", version = "0.0.7")
 
+bazel_dep(name = "rules_shell", version = "0.8.0", dev_dependency = True)
+
 host_platform = use_extension("//host:extension.bzl", "host_platform")
 use_repo(host_platform, "host_platform")

--- a/tests/host/BUILD
+++ b/tests/host/BUILD
@@ -1,3 +1,4 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//host:constraints.bzl", "HOST_CONSTRAINTS")
 
 package(default_visibility = ["//visibility:private"])


### PR DESCRIPTION
Adds a dependency on rules_shell and the correct load statements.